### PR TITLE
[FEATURE] Add Support for dropShadow with Flexible Color Options and Fix GridOption

### DIFF
--- a/src/LarapexChart.php
+++ b/src/LarapexChart.php
@@ -46,6 +46,7 @@ class LarapexChart
     public string $theme = 'light';
     public string $sparkline;
     public string $chartLetters = 'abcdefghijklmnopqrstuvwxyz';
+    public string $dropShadow = '';
 
     public ?XAxisOption $xAxisOption = null;
     public ?YAxisOption $yAxisOption = null;
@@ -238,6 +239,21 @@ class LarapexChart
         return $this;
     }
 
+    public function setDropShadow(bool $enabled = true, string|array $color = '#000', int $top = 10, int $left = 5, int $blur = 3, float $opacity = 0.2, ?array $enabledOnSeries = []): static
+    {
+        $this->dropShadow = json_encode([
+            'enabled' => $enabled,
+            'enabledOnSeries' => $enabledOnSeries,
+            'top' => $top,
+            'left' => $left,
+            'blur' => $blur,
+            'color' => is_array($color) ? $color : [$color],
+            'opacity' => $opacity,
+        ]);
+
+        return $this;
+    }
+
     public function setAdditionalOptions(array $options): static
     {
         $this->additionalOptions = $options;
@@ -373,6 +389,10 @@ class LarapexChart
 
         if ($this->gridOption !== null && $this->gridOption->toArray() !== []) {
             $options['grid'] = $this->gridOption->toArray();
+        }
+
+        if ($this->dropShadow !== '') {
+            $options['chart']['dropShadow'] = json_decode($this->dropShadow);
         }
 
         return $options;

--- a/src/Options/GridOption.php
+++ b/src/Options/GridOption.php
@@ -86,15 +86,15 @@ class GridOption implements Arrayable
     public function toArray(): array
     {
         $data = [
-            'show' => $this->show ? 'true' : 'false',
+            'show' => $this->show ? true : false,
             'xaxis' => [
                 'lines' => [
-                    'show' => $this->showXAxis ? 'true' : 'false'
+                    'show' => $this->showXAxis ? true : false
                 ]
             ],
             'yaxis' => [
                 'lines' => [
-                    'show' => $this->showYAxis ? 'true' : 'false'
+                    'show' => $this->showYAxis ? true : false
                 ]
             ]
         ];


### PR DESCRIPTION
#### Summary
This PR introduces the following key changes to the `LarapexChart` class:
1. **Enhanced `dropShadow` Functionality**: 
    - The `dropShadow` configuration in ApexCharts now supports both single string values and an array of colors, allowing different shadow colors for each series. 
    - Added the `enabledOnSeries` parameter to control which series have the drop shadow enabled, in line with the official ApexCharts documentation.
  
2. **Fixes for `GridOption` Class**: 
    - Corrected an issue where grid settings were not properly applied. Now, all grid-related options should work as expected when passed to the chart configuration.

#### Changes Made
- **New `setDropShadow` method in `LarapexChart`**:
    - Supports both string and array values for `color`.
    - Allows more fine-grained control with `enabledOnSeries` for specific series.
- **Fixes to the `GridOption` class** to ensure grid settings are properly handled and passed to the chart configuration.

#### Examples of Usage:
```php
// Single shadow color applied to all series
$chart = (new LarapexChart)
    ->setDropShadow(enabled: true, color: '#FF0000');

// Different shadow colors for different series
$chart = (new LarapexChart)
    ->setDropShadow(enabled: true, color: ['#FF0000', '#00FF00'], enabledOnSeries: [0, 1]);
```

#### Fixes:
- Resolved issues with `GridOption` where grid settings were not applied correctly in chart configuration.

#### Additional Notes:
- This change is fully backward-compatible.
- Please ensure to test the `GridOption` changes for any edge cases not covered during initial development.

#### Related Documentation:
- ApexCharts `dropShadow` documentation: https://apexcharts.com/docs/options/chart/dropshadow/

---

This should provide a clear and comprehensive overview of the changes made and the reason behind them.
